### PR TITLE
fix: GetLiquidations return empty vaults if can not get price

### DIFF
--- a/x/vaults/keeper/vault.go
+++ b/x/vaults/keeper/vault.go
@@ -507,9 +507,11 @@ func (k *Keeper) GetLiquidations(
 		}
 		collateralSymbol := vm.Symbol
 		mintSymbol := vm.Params.MintSymbol
+		
+		// If can not get price of denom, skip!
 		price, err := k.OracleKeeper.GetPrice(ctx, collateralSymbol, mintSymbol)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		prices[vm.Denom] = price
 		liquidationRatios[vm.Denom] = vm.Params.LiquidationRatio


### PR DESCRIPTION
Fix bug reported: `105 Uncaught (in promise) Error: Query failed with (18): symbol NOM old price state: invalid request`